### PR TITLE
表示するスタッフを実行委員長とコアスタッフのみにする

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -11,6 +11,7 @@ const sponsorsMap = {
 const getSponsorKey = plan_name => {
   return sponsorsMap[plan_name]
 }
+const acceptStaffTitles = ["実行委員長", "コアスタッフ"]
 
 export const actions = {
   async fetchSponsors(){
@@ -28,6 +29,9 @@ export const actions = {
     const {data} = await this.$axios.get("/staff")
     const staffs = []
     for (let title of Object.keys(data.staff)) {
+      if (acceptStaffTitles.indexOf(title) === -1) {
+        continue
+      }
       for(let staff of data.staff[title]) {
         staffs.push(staff)
       }


### PR DESCRIPTION
名札出力のために当日スタッフにforteeを登録してもらいましたが、サイトにも当日スタッフが掲載されるようになってしまいました。  
サイトには実行委員長とコアスタッフのみを掲載したいので、そちらの修正になります。